### PR TITLE
Use tabs as keyword/identifier separator

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,2 +1,2 @@
-Blink KEYWORD1
-Update     KEYWORD2
+Blink	KEYWORD1
+Update	KEYWORD2


### PR DESCRIPTION
Arduino IDE does not recognize keywords unless they are separated from
the identifier by a tab, as stated in the [Arduino Library specification](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords). This chance causes the Blink and Update keywords to be highlighted in the Arduino IDE editor.
